### PR TITLE
fix: send UDP errors to the correct GenServer

### DIFF
--- a/lib/udp/event_handler.ex
+++ b/lib/udp/event_handler.ex
@@ -17,7 +17,6 @@ defmodule TelemetryInfluxDB.UDP.EventHandler do
   def init(config) do
     Process.flag(:trap_exit, true)
     config = %{config | port: :erlang.integer_to_binary(config.port)}
-    config = Map.put(config, :reporter, self())
     handler_ids = attach_events(config.events, config)
 
     {:ok, %{handler_ids: handler_ids}}
@@ -60,7 +59,7 @@ defmodule TelemetryInfluxDB.UDP.EventHandler do
         :ok
 
       {:error, reason} ->
-        Connector.udp_error(config.reporter, udp, reason)
+        Connector.udp_error(config.reporter_name, udp, reason)
     end
   end
 


### PR DESCRIPTION
`Connector.udp_error` was `cast`ing an error message to the configured `reporter` pid, which was the `UDP.ErrorHandler` GenServer. However, the `handle_cast` implementation was in `UDP.Connector` instead, so any UDP errors were being sent to the wrong GenServer.

This PR registers the `UDP.Connector` GenServer with a name derived from `config.reporter_name` and then `cast`s the error message to that GenServer by name.
