### PR TITLE
chore: upgrade to influxdb 2.0.0 RC 1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,8 +24,8 @@ start_influx_v1: stop_influx_v1
 	--name=${CONTAINER_NAME_V1} influxdb -config /etc/influxdb/influxdb-meta.conf
 
 start_influx_v2: stop_influx_v2
-	docker run -tid -p 9999:9999 \
-	--name=${CONTAINER_NAME_V2} quay.io/influxdb/influxdb:2.0.0-beta
+	docker run -tid -p 9999:8086 \
+	--name=${CONTAINER_NAME_V2} quay.io/influxdb/influxdb:2.0.0-rc
 
 wait_for_influx: wait_for_influx_v1 provision_influx_v2
 

--- a/test/telemetry_influx_db_test.exs
+++ b/test/telemetry_influx_db_test.exs
@@ -553,8 +553,7 @@ defmodule TelemetryInfluxDBTest do
   end
 
   defp do_clear_series(%{version: :v2} = config, name) do
-    predicate = "_measurement=\"#{name}\""
-    InfluxSimpleClient.V2.delete(config, predicate)
+    InfluxSimpleClient.V2.delete_measurement(config, name)
   end
 
   defp refute_reported(context, name) do

--- a/test/telemetry_influx_db_test.exs
+++ b/test/telemetry_influx_db_test.exs
@@ -698,7 +698,6 @@ defmodule TelemetryInfluxDBTest do
   defp make_config(%{version: :v2, protocol: :http, token: token}, overrides) do
     @default_config
     |> be_v2(token)
-    |> Map.merge(%{protocol: :http, port: 9999})
     |> Map.merge(overrides)
   end
 


### PR DESCRIPTION
Updates the tests/library to work with the latest InfluxDB 2.0 RC version.

Changes:

No changes to the library itself were needed; only the tests (and test setup code in the Makefile) were affected.

Default port is now 8086 to match InfluxDB 1.x. This updates the tests to map that port in the Docker container to 9999 on the host, which allows everything else to stay the same.

"Delete with predicate" API has been disabled in 2.0-rc for now (see influxdata/influxdb#19580). While it will return in the future (most likely after the 2.0 GA release - see influxdata/influxdb#19635), we need a way to clean up the DB between tests in the mean time.

I decided to use the 1.x compatibility API that is new in the RC version. That API doesn't implement the DROP SERIES statement that the 1.x tests here use, but does implement DROP MEASUREMENT which works just as well for our needs.

In order to use the 1.x /query endpoint against a 2.0 bucket, there needs to be a "database and retention policy mapping" (see https://docs.influxdata.com/influxdb/v2.0/reference/api/influxdb-1x/dbrp/). I've updated the provision_influx_v2 target in the Makefile to a) capture the token, org ID, and bucket ID from the setup call; b) store the token in the .token file as before, and c) create the necessary mapping.

With these changes, the tests are now working with the latest RC version of InfluxDB 2.0.

I also removed an unnecessary Map.merge call in the tests; the be_v2 function was already providing those parameters, and now we have one less line that duplicates the port number.