### PR TITLE
Do not use regex to escape special characters

### DIFF
--- a/lib/formatter.ex
+++ b/lib/formatter.ex
@@ -45,7 +45,21 @@ defmodule TelemetryInfluxDB.Formatter do
   end
 
   # https://docs.influxdata.com/influxdb/v1.7/write_protocols/line_protocol_tutorial/
-  defp escape_special_chars(string) do
-    Regex.replace(~r/[=|,| |\"]/, string, fn a, _ -> "\\" <> a end)
+  defp escape_special_chars(str) do
+    escape_special_chars(str, "")
   end
+
+  defp escape_special_chars(<<>>, acc), do: acc
+
+  defp escape_special_chars(<<c::8, rest::binary>>, acc) do
+    escape_special_chars(rest, acc <> e(<<c>>))
+  end
+
+  @compile {:inline, e: 1}
+
+  defp e(<<"=">>), do: "\\="
+  defp e(<<",">>), do: "\\,"
+  defp e(<<"\"">>), do: "\\\""
+  defp e(<<" ">>), do: "\\ "
+  defp e(c), do: c
 end


### PR DESCRIPTION
Hi there, I'd like to propose a small optimization to the formatter code.

After profiling some code that was using telemetry, I noticed that most of the time was being spent dealing with regexes in the `:re` erlang module. This PR improves things a bit. For cases where the formatter has to escape special characters, the recurring solution is ~2x faster than using Regex.

This was the benchmark:
```
Benchee.run(
      %{
        "formatting" => fn input ->
          Formatter.format([:special, :coma], input)
        end
      },
      inputs: %{
        "quote" => %{field: "quote\""},
        "space" => %{field: "my space"},
        "equals" => %{field: "e=quals"},
        "coma" => %{field: ",coma"},
        "boolean" => %{my_boolean: true},
        "fake_int" => %{my_fake_int: "123"},
        "map" => %{my_map: %{key1: "jacknicholson"}},
        "string" => %{my_string: "jacknicholson"},
        "multiple" => %{"field1" => "field1_val", "field2" => "field2_val"}
      },
      memory_time: 2,
      save: [
        path: @results_data_file,
        tag: "original"
      ],
      load: @results_data_file
    )
```
And here are the results:
```
##### With input boolean #####
Name                             ips        average  deviation         median         99th %
formatting                  583.95 K        1.71 μs  ±1472.44%           1 μs           3 μs
formatting (recursive)      559.87 K        1.79 μs  ±1817.95%           1 μs           3 μs

Comparison: 
formatting                  583.95 K
formatting (recursive)      559.87 K - 1.04x slower +0.0736 μs

Memory usage statistics:

Name                      Memory usage
formatting                       688 B
formatting (recursive)           688 B - 1.00x memory usage +0 B

**All measurements for memory usage were the same**

##### With input equals #####
Name                             ips        average  deviation         median         99th %
formatting (recursive)      400.97 K        2.49 μs   ±979.87%           2 μs           4 μs
formatting                  161.74 K        6.18 μs   ±224.96%           6 μs          16 μs

Comparison: 
formatting (recursive)      400.97 K
formatting                  161.74 K - 2.48x slower +3.69 μs

Memory usage statistics:

Name                      Memory usage
formatting (recursive)         1.26 KB
formatting                     1.36 KB - 1.08x memory usage +0.102 KB

**All measurements for memory usage were the same**

##### With input fake_int #####
Name                             ips        average  deviation         median         99th %
formatting (recursive)      439.63 K        2.27 μs  ±1177.65%           2 μs           4 μs
formatting                  233.51 K        4.28 μs   ±435.28%           4 μs          11 μs

Comparison: 
formatting (recursive)      439.63 K
formatting                  233.51 K - 1.88x slower +2.01 μs

Memory usage statistics:

Name                      Memory usage
formatting (recursive)         1.07 KB
formatting                     1.02 KB - 0.95x memory usage -0.05469 KB

**All measurements for memory usage were the same**

##### With input map #####
Name                             ips        average  deviation         median         99th %
formatting                  597.69 K        1.67 μs  ±1012.56%           1 μs           3 μs
formatting (recursive)      575.29 K        1.74 μs  ±1200.84%           1 μs           3 μs

Comparison: 
formatting                  597.69 K
formatting (recursive)      575.29 K - 1.04x slower +0.0651 μs

Memory usage statistics:

Name                      Memory usage
formatting                       712 B
formatting (recursive)           712 B - 1.00x memory usage +0 B

**All measurements for memory usage were the same**

##### With input multiple #####
Name                             ips        average  deviation         median         99th %
formatting (recursive)      172.82 K        5.79 μs   ±400.05%           5 μs          19 μs
formatting                   86.79 K       11.52 μs   ±147.22%          10 μs          32 μs

Comparison: 
formatting (recursive)      172.82 K
formatting                   86.79 K - 1.99x slower +5.74 μs

Memory usage statistics:

Name                      Memory usage
formatting (recursive)         4.48 KB
formatting                     2.32 KB - 0.52x memory usage -2.15625 KB

**All measurements for memory usage were the same**

##### With input quote #####
Name                             ips        average  deviation         median         99th %
formatting (recursive)      395.82 K        2.53 μs  ±1059.82%           2 μs           4 μs
formatting                  142.66 K        7.01 μs   ±394.18%           6 μs          22 μs

Comparison: 
formatting (recursive)      395.82 K
formatting                  142.66 K - 2.77x slower +4.48 μs

Memory usage statistics:

Name                      Memory usage
formatting (recursive)         1.37 KB
formatting                     1.46 KB - 1.07x memory usage +0.0938 KB

**All measurements for memory usage were the same**

##### With input space #####
Name                             ips        average  deviation         median         99th %
formatting (recursive)      366.35 K        2.73 μs   ±743.09%           2 μs           5 μs
formatting                   46.24 K       21.63 μs   ±820.93%           8 μs         161 μs

Comparison: 
formatting (recursive)      366.35 K
formatting                   46.24 K - 7.92x slower +18.90 μs

Memory usage statistics:

Name                      Memory usage
formatting (recursive)         1.58 KB
formatting                     1.51 KB - 0.96x memory usage -0.07031 KB

**All measurements for memory usage were the same**

##### With input string #####
Name                             ips        average  deviation         median         99th %
formatting (recursive)      319.21 K        3.13 μs   ±733.66%           3 μs           5 μs
formatting                  217.53 K        4.60 μs   ±412.85%           4 μs          13 μs

Comparison: 
formatting (recursive)      319.21 K
formatting                  217.53 K - 1.47x slower +1.46 μs

Memory usage statistics:

Name                      Memory usage
formatting (recursive)         2.10 KB
formatting                     1.03 KB - 0.49x memory usage -1.07031 KB
```
